### PR TITLE
fix: update navigation link to gluestack

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The chat system is built using FHIR `Communication` and `Subscription` resources
 
 ### UI components
 
-UI components are built using [gluestack-ui v2](https://ui.gluestack.com/). All original components from the library are kept as-is under the `components/ui` directory, but additional components are added to the same directory to support the app's requirements. Domain-specific components are at `components` directory.
+UI components are built using [gluestack-ui v2](https://gluestack.io/). All original components from the library are kept as-is under the `components/ui` directory, but additional components are added to the same directory to support the app's requirements. Domain-specific components are at `components` directory.
 
 ## Getting Started
 


### PR DESCRIPTION

This PR update navigation link to gluestack, `https://ui.gluestack.com/` to `https://gluestack.io`

Error:  `https://ui.gluestack.com/`

<img width="688" alt="Screenshot 2024-12-24 at 16 36 49" src="https://github.com/user-attachments/assets/17ea663b-4145-4bdf-a1fe-615e29778bcf" />
